### PR TITLE
Fix: Macros, segunda parte

### DIFF
--- a/00002_Macros, segunda parte/description.md
+++ b/00002_Macros, segunda parte/description.md
@@ -11,7 +11,7 @@ end
 ```
 Y esto también aplica a la herencia y a los mixins: por ejemplo, si un mixin provee un método de clase, éste puede ser utilizado desde el cuerpo de la clase que lo incluya. ¡Y así es como surgen los _macros_ `attr_accesor`, `include`, etc!
 
-> Veamos si se entiende: definí `ensure_no_override` que toma un selector y lanza una excepción si ya existe este método. Definilo en la clase `Module` así tanto las clases como los métodos lo pueden aprovechar. Ejemplo:
+> Veamos si se entiende: definí `ensure_no_override` que toma un selector y lanza la excepción `NameError` si ya existe este método. Definilo en la clase `Module` así tanto las clases como los métodos lo pueden aprovechar. Ejemplo:
 > 
 > ```ruby
 > class Pepita

--- a/00002_Macros, segunda parte/test..rb
+++ b/00002_Macros, segunda parte/test..rb
@@ -5,7 +5,7 @@ describe "ensure_no_override" do
       def foo
       end
     end
-    expect { class Foo; ensure_no_override :foo; end }.to raise_error
+    expect { class Foo; ensure_no_override :foo; end }.to raise_error NameError
   end
 
   it "no falla si el metodo no existia" do


### PR DESCRIPTION
El assert de `raise_error` sin especificar qué excepción esperar tira un Warning que "rompe" la plataforma (no muestra los resultados de los tests).

Cambié el enunciado y el test para que se lance la excepción `NameError`.

### Advertencia: Esto no fue probado!